### PR TITLE
MM7Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
 		<junit.version>4.12</junit.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
 		<mimepull.version>1.9.4</mimepull.version>
+		<spring.version>4.2.5.RELEASE</spring.version>
+		<jetty.version>9.3.8.v20160314</jetty.version>
 	</properties>
 
 	<dependencies>
@@ -56,6 +58,11 @@
 			<groupId>org.jvnet.mimepull</groupId>
 			<artifactId>mimepull</artifactId>
 			<version>${mimepull.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>${spring.version}</version>
 		</dependency>
 
 		<!-- Optional, provided and test dependencies -->
@@ -75,6 +82,18 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/net/instantcom/mm7/MM7ServletInJettyWithSpring.java
+++ b/src/test/java/net/instantcom/mm7/MM7ServletInJettyWithSpring.java
@@ -1,0 +1,55 @@
+package net.instantcom.mm7;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.springframework.web.context.ContextLoaderListener;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * starting up Jetty with {@link MM7Servlet} wired up with Spring
+ * </p>
+ * Created by bardug on 6/26/2016.
+ */
+public class MM7ServletInJettyWithSpring {
+
+    private Server webServer;
+
+    public static void main(String[] args) throws Exception {
+        new MM7ServletInJettyWithSpring().start();
+    }
+
+    private void start() throws Exception {
+        initJetty();
+        addServletContext();
+        webServer.start();
+    }
+
+    private void initJetty() {
+        webServer = new Server();
+        ServerConnector httpConnector = new ServerConnector(webServer);
+        httpConnector.setPort(8080);
+        httpConnector.setHost("127.0.0.1");
+        httpConnector.setIdleTimeout(30000);
+
+        webServer.addConnector(httpConnector);
+    }
+
+    private void addServletContext() throws IOException {
+        ServletContextHandler context = new ServletContextHandler(webServer, "/", ServletContextHandler.SESSIONS);
+        context.setSessionHandler(new SessionHandler());
+
+        // Setup Spring context
+        context.addEventListener(new ContextLoaderListener());
+        context.setInitParameter("contextConfigLocation", "classpath:net/instantcom/mm7/spring-context.xml");
+
+        // MM7 servlet
+        ServletHolder mm7Servlet = new ServletHolder(MM7Servlet.class);
+        context.setAttribute(MM7Servlet.VASP_BEAN_ATTRIBUTE, "mm7Vasp"); // bean id as configured in spring xml context
+        context.addServlet(mm7Servlet, "/mm7");
+    }
+}

--- a/src/test/java/net/instantcom/mm7/SampleSpringVASP.java
+++ b/src/test/java/net/instantcom/mm7/SampleSpringVASP.java
@@ -1,0 +1,27 @@
+package net.instantcom.mm7;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * <p>
+ * sample VASP to use with {@link MM7ServletInJettyWithSpring}
+ * </p>
+ * Created by bardug on 6/26/2016.
+ */
+public class SampleSpringVASP implements VASP {
+
+    @Autowired
+    private MM7Context context;
+
+    @Override
+    public DeliverRsp deliver(DeliverReq deliverReq) throws MM7Error {
+        System.out.println("deliver in VASP was called");
+
+        return null;
+    }
+
+    @Override
+    public MM7Context getContext() {
+        return context;
+    }
+}

--- a/src/test/resources/net/instantcom/mm7/spring-context.xml
+++ b/src/test/resources/net/instantcom/mm7/spring-context.xml
@@ -1,0 +1,11 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+
+    <bean id="mm7Context" class="net.instantcom.mm7.MM7Context"/>
+
+    <bean id="mm7Vasp" class="net.instantcom.mm7.SampleSpringVASP"/>
+
+</beans>


### PR DESCRIPTION
changes in MM7Servlet
    support VASP configuration in a Spring-wired application
    overriding no-arg init() method of GenericServlet is better than overriding init(ServletConfig) according javadoc
