### PR TITLE
Support for Delivery Report

### DIFF
--- a/src/main/java/net/instantcom/mm7/MM7Servlet.java
+++ b/src/main/java/net/instantcom/mm7/MM7Servlet.java
@@ -76,8 +76,10 @@ public class MM7Servlet extends HttpServlet {
 		MM7Response resp;
 		if (req instanceof DeliverReq) {
 			resp = getVasp().deliver((DeliverReq) req);
+		} else if (req instanceof DeliveryReportReq) {
+			resp = getVasp().deliveryReport((DeliveryReportReq) req);
 		} else {
-			throw new MM7Error("method not supported");
+			throw new MM7Error("method not supported: " + req.getClass() );
 		}
 		return resp;
 	}

--- a/src/main/java/net/instantcom/mm7/VASP.java
+++ b/src/main/java/net/instantcom/mm7/VASP.java
@@ -39,6 +39,19 @@ public interface VASP {
 	 *             if message can't be delivered
 	 */
 	DeliverRsp deliver(DeliverReq deliverReq) throws MM7Error;
+	
+	/**
+	 * Handles delivery report from MMSC.
+	 *
+	 * @param DeliveryReportReq
+	 *            MMS delivery report delivered from MMSC.
+	 *
+	 * @return deliveryReportRsp instance
+	 *
+	 * @throws MM7Error
+	 *             if message can't be process
+	 */
+	DeliveryReportRsp deliveryReport(DeliveryReportReq deliveryReportReq) throws MM7Error;
 
 	/**
 	 * Context used for serializing/deserializing MM7 messages.

--- a/src/test/java/net/instantcom/mm7/SampleSpringVASP.java
+++ b/src/test/java/net/instantcom/mm7/SampleSpringVASP.java
@@ -24,4 +24,11 @@ public class SampleSpringVASP implements VASP {
     public MM7Context getContext() {
         return context;
     }
+
+	@Override
+	public DeliveryReportRsp deliveryReport(DeliveryReportReq deliveryReportReq) throws MM7Error {
+		System.out.println("deliver in VASP was called");
+
+        return null;
+	}
 }


### PR DESCRIPTION
- add `deliveryReport` method into `VASP` interface
- change `MM7Servlet` to call `VASP.deliveryReport` upon receive MM7
`DeliverReportReq`
- print MM7Request class name upon unsupported method