### PR TITLE
special handling for apache-commons Base64OutputStream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,14 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>java-rt</groupId>
+			<artifactId>java-rt</artifactId>
+			<version>IGNORED</version>
+			<scope>system</scope>
+			<systemPath>${java.home}/lib/rt.jar</systemPath>
+		</dependency>
+
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>${servlet-api.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,14 +74,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>java-rt</groupId>
-			<artifactId>java-rt</artifactId>
-			<version>IGNORED</version>
-			<scope>system</scope>
-			<systemPath>${java.home}/lib/rt.jar</systemPath>
-		</dependency>
-
-		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>${servlet-api.version}</version>

--- a/src/main/java/net/instantcom/mm7/MM7Context.java
+++ b/src/main/java/net/instantcom/mm7/MM7Context.java
@@ -104,6 +104,10 @@ public class MM7Context {
 				s.write("test123".getBytes("iso-8859-1"));
 				s.close();
 				String encoded = baos.toString("iso-8859-1");
+				if (BASE64_OUTPUT_STREAM_CLASSES[0].equals(base64OutputStream.getName())) {
+				    // commons-codec with the default constructor adds a newline to test output
+				    encoded = encoded.trim();
+				}
 				if (!encoded.equals("dGVzdDEyMw==")) {
 					throw new IllegalArgumentException(base64OutputStream.getName()
 							+ " incorrectly encodes BASE64 data");

--- a/src/test/java/net/instantcom/mm7/Base64EncoderTest.java
+++ b/src/test/java/net/instantcom/mm7/Base64EncoderTest.java
@@ -21,8 +21,6 @@ package net.instantcom.mm7;
 import org.apache.commons.codec.binary.Base64OutputStream;
 import org.junit.Test;
 
-import com.sun.xml.internal.messaging.saaj.packaging.mime.util.BASE64EncoderStream;
-
 /**
  * Test Base64 encoder construction
  */
@@ -32,11 +30,5 @@ public class Base64EncoderTest {
 	public void base64ApacheCommons() {
 		MMSC mmsc = new BasicMMSC("http://localhost:8080");
 		mmsc.getContext().setBase64OutputStream(Base64OutputStream.class);
-	}
-
-	@Test
-	public void base64SunSAAJ() {
-		MMSC mmsc = new BasicMMSC("http://localhost:8080");
-		mmsc.getContext().setBase64OutputStream(BASE64EncoderStream.class);
 	}
 }

--- a/src/test/java/net/instantcom/mm7/Base64EncoderTest.java
+++ b/src/test/java/net/instantcom/mm7/Base64EncoderTest.java
@@ -1,0 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2007-2014 InstantCom Ltd. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://raw.github.com/vnesek/instantcom-mm7/master/LICENSE.txt
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at appropriate location.
+ */
+
+package net.instantcom.mm7;
+
+import org.apache.commons.codec.binary.Base64OutputStream;
+import org.junit.Test;
+
+import com.sun.xml.internal.messaging.saaj.packaging.mime.util.BASE64EncoderStream;
+
+/**
+ * Test Base64 encoder construction
+ */
+public class Base64EncoderTest {
+
+	@Test
+	public void base64ApacheCommons() {
+		MMSC mmsc = new BasicMMSC("http://localhost:8080");
+		mmsc.getContext().setBase64OutputStream(Base64OutputStream.class);
+	}
+
+	@Test
+	public void base64SunSAAJ() {
+		MMSC mmsc = new BasicMMSC("http://localhost:8080");
+		mmsc.getContext().setBase64OutputStream(BASE64EncoderStream.class);
+	}
+}


### PR DESCRIPTION
apache-commons Base64OutputStream works just fine with the default
constructor. It just adds a newline whereas BASE64EncoderStream doesn't.
This made the test in setBase64OutputStream fail.