### PR TITLE
Support for SOAP Fault that is not standard compliant

### DIFF
--- a/src/main/java/net/instantcom/mm7/MM7Error.java
+++ b/src/main/java/net/instantcom/mm7/MM7Error.java
@@ -79,12 +79,25 @@ public class MM7Error extends Exception implements JDOMSupport {
 		
 		this.faultCode = e.getChildTextTrim("faultcode");
 		this.faultMessage = e.getChildTextTrim("faultstring");
+		
+		if(faultCode == null) {
+			this.faultCode = e.getChildTextTrim("faultcode", MM7Message.ENVELOPE);
+		}
+		
+		if(faultMessage == null) {
+			this.faultMessage = e.getChildTextTrim("faultstring", MM7Message.ENVELOPE);
+		}		
+
 		try {
 			Element detail;
 			if (element.getNamespace("") != null) {
 				 detail = (Element) e.getChild("detail",element.getNamespace("")).getChildren().get(0);
 			} else {
-				 detail = (Element) e.getChild("detail").getChildren().get(0);
+				 if(e.getChild("detail") != null) {
+					 detail = (Element) e.getChild("detail").getChildren().get(0);
+				 } else {
+					 detail = (Element) e.getChild("detail", MM7Message.ENVELOPE).getChildren().get(0);
+				 }				 
 			}
 			String message = detail.getName();
 			// Instantiate correct status type

--- a/src/main/java/net/instantcom/mm7/MM7Message.java
+++ b/src/main/java/net/instantcom/mm7/MM7Message.java
@@ -209,7 +209,8 @@ public class MM7Message implements JDOMSupport {
 
 	private static BasicContent fromPart(MIMEPart part, ContentType contentType) throws IOException {
 		BasicContent result;
-		if (contentType.getPrimaryType().equals("text") || contentType.getSubType().equals("smilx")) {
+		if (contentType.getPrimaryType().equals("text") || contentType.getSubType().equals("smilx")
+				|| contentType.getMimeTypeWithoutParams().equals("application/xml")) {
 			if (contentType.getSubType().equals("xml")) {
 				result = new SoapContent(part.readOnce());
 			} else {
@@ -255,7 +256,8 @@ public class MM7Message implements JDOMSupport {
 				contents.add(content);
 			}
 			result = new BasicContent(contents);
-		} else if (contentType.getMimeTypeWithoutParams().equals("text/xml")) {
+		} else if (contentType.getMimeTypeWithoutParams().equals("text/xml") 
+				|| contentType.getMimeTypeWithoutParams().equals("application/xml")) {
 			result = new SoapContent(in);
 		} else if (contentType.getPrimaryType().equals("text")) {
 			TextContent text = new TextContent();

--- a/src/main/java/net/instantcom/mm7/MM7Response.java
+++ b/src/main/java/net/instantcom/mm7/MM7Response.java
@@ -120,7 +120,11 @@ public class MM7Response extends MM7Message {
 			if (element.getNamespace("") != null) {
 				 child = (Element) child.getChild("detail",element.getNamespace("")).getChildren().get(0);
 			} else {
-				 child = (Element) child.getChild("detail").getChildren().get(0);
+				 if(child.getChild("detail") != null) {
+					 child = (Element) child.getChild("detail").getChildren().get(0);
+				 } else {
+					 child = (Element) child.getChild("detail", MM7Message.ENVELOPE).getChildren().get(0);
+				 }
 			}
 		}
 

--- a/src/test/java/net/instantcom/mm7/FaultLoadSample.java
+++ b/src/test/java/net/instantcom/mm7/FaultLoadSample.java
@@ -32,5 +32,16 @@ public class FaultLoadSample {
 			System.out.println("=== Complete SOAP body ===");
 			System.out.println(e);
 		}
+		
+		
+		InputStream is2 = FaultLoadSample.class.getResourceAsStream("fault_02.xml");
+
+		try {
+			MM7Message.load(is2, "text/xml", new MM7Context());
+		} catch (MM7Error e) {
+			System.out.println(e.getResponse());
+			System.out.println("=== Complete SOAP body ===");
+			System.out.println(e);
+		}
 	}
 }

--- a/src/test/resources/net/instantcom/mm7/fault_02.xml
+++ b/src/test/resources/net/instantcom/mm7/fault_02.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+    <TransactionID xmlns="http://www.3gpp.org/ftp/Specs/archive/23_series/23.140/schema/REL-5-MM7-1-3" env:mustUnderstand="1">0_1500103103727</TransactionID>
+  </env:Header>
+  <env:Body>
+    <env:Fault>
+      <env:faultcode>env:Client</env:faultcode>
+      <env:faultstring>Client error</env:faultstring>
+      <env:detail>
+        <RSErrorRsp xmlns="http://www.3gpp.org/ftp/Specs/archive/23_series/23.140/schema/REL-5-MM7-1-3">
+          <MM7Version>5.3.0</MM7Version>
+          <Status>
+            <StatusCode>2002</StatusCode>
+            <StatusText>Address Error</StatusText>
+          </Status>
+        </RSErrorRsp>
+      </env:detail>
+    </env:Fault>
+  </env:Body>
+</env:Envelope>


### PR DESCRIPTION
Support for SOAP Fault that is not standard compliant

- modify MM7Error.java and MM7Response.java, to make it able to extract information from SOAP fault that is not standard compliant
- add new file fault_02.xml which is an example of non standard compliant SOAP fault
- modify FaultLoadSample.java to also test on fault_02.xml