### PR TITLE
Fix base64 incomplete output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 	<properties>
 		<jdom.version>2.0.2</jdom.version>
 		<commons-codec.version>1.10</commons-codec.version>
+		<javax-mail.version>1.5.0-b01</javax-mail.version>
 		<junit.version>4.12</junit.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
 		<mimepull.version>1.9.4</mimepull.version>
@@ -72,6 +73,12 @@
 			<artifactId>commons-codec</artifactId>
 			<version>${commons-codec.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+		    <groupId>javax.mail</groupId>
+		    <artifactId>mail</artifactId>
+		    <version>${javax-mail.version}</version>
+		    <scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -119,7 +126,7 @@
 		<snapshotRepository>
 			<id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
+		</snapshotRepository>		
 	</distributionManagement>
 
 	<profiles>

--- a/src/main/java/net/instantcom/mm7/BinaryContent.java
+++ b/src/main/java/net/instantcom/mm7/BinaryContent.java
@@ -135,7 +135,7 @@ public class BinaryContent extends BasicContent {
 			b.append("\r\nContent-ID: <" + contentId + ">");
 		}
 
-		boolean sevenBit = "application/smil".equals(getContentType());
+		boolean sevenBit = ("application/smil".equals(getContentType()) || "application/smil+xml".equals(getContentType())); 
 		if (sevenBit) {
 			b.append("\r\nContent-Transfer-Encoding: 7bit");
 		} else {

--- a/src/main/java/net/instantcom/mm7/BinaryContent.java
+++ b/src/main/java/net/instantcom/mm7/BinaryContent.java
@@ -150,9 +150,13 @@ public class BinaryContent extends BasicContent {
 		out.write(b.toString().getBytes("iso-8859-1"));
 		
 		if(sevenBit){
-			out.write(data);	
+			out.write(data);
+			out.flush();
 		} else {
-			ctx.newBase64OutputStream(out).write(data);
+			OutputStream base64out = ctx.newBase64OutputStream(out);
+			
+			base64out.write(data);
+			base64out.flush();
 		}
 		
 	}

--- a/src/main/java/net/instantcom/mm7/MM7Context.java
+++ b/src/main/java/net/instantcom/mm7/MM7Context.java
@@ -34,7 +34,8 @@ import org.jvnet.mimepull.MIMEConfig;
 public class MM7Context {
 
 	private static String[] BASE64_OUTPUT_STREAM_CLASSES = { "org.apache.commons.codec.binary.Base64OutputStream",
-			"com.sun.xml.internal.messaging.saaj.packaging.mime.util.BASE64EncoderStream" };
+			"com.sun.xml.internal.messaging.saaj.packaging.mime.util.BASE64EncoderStream",
+			"com.sun.mail.util.BASE64EncoderStream"};
 
 	public Class<? extends OutputStream> getBase64OutputStream() {
 		return base64OutputStream;
@@ -104,8 +105,9 @@ public class MM7Context {
 				s.write("test123".getBytes("iso-8859-1"));
 				s.close();
 				String encoded = baos.toString("iso-8859-1");
-				if (BASE64_OUTPUT_STREAM_CLASSES[0].equals(base64OutputStream.getName())) {
-				    // commons-codec with the default constructor adds a newline to test output
+				if (BASE64_OUTPUT_STREAM_CLASSES[0].equals(base64OutputStream.getName()) || 
+						BASE64_OUTPUT_STREAM_CLASSES[2].equals(base64OutputStream.getName()) ){
+				    // commons-codec and javax.mail with the default constructor adds a newline to test output
 				    encoded = encoded.trim();
 				}
 				if (!encoded.equals("dGVzdDEyMw==")) {

--- a/src/test/java/net/instantcom/mm7/Base64EncoderTest.java
+++ b/src/test/java/net/instantcom/mm7/Base64EncoderTest.java
@@ -21,6 +21,8 @@ package net.instantcom.mm7;
 import org.apache.commons.codec.binary.Base64OutputStream;
 import org.junit.Test;
 
+import com.sun.mail.util.BASE64EncoderStream;
+
 /**
  * Test Base64 encoder construction
  */
@@ -30,5 +32,11 @@ public class Base64EncoderTest {
 	public void base64ApacheCommons() {
 		MMSC mmsc = new BasicMMSC("http://localhost:8080");
 		mmsc.getContext().setBase64OutputStream(Base64OutputStream.class);
+	}
+	
+	@Test
+	public void base64JavaxMail() {
+		MMSC mmsc = new BasicMMSC("http://localhost:8080");
+		mmsc.getContext().setBase64OutputStream(BASE64EncoderStream.class);
 	}
 }


### PR DESCRIPTION
Fix Base64 incomplete encoded output

- common-codec `Base64OutputStream` expect stream to be close in order to send final padding bytes to output, which is not a workable option when handling multiple attachment in 1 MMS
- add options of using javax.mail Base64EncoderStream which do not required the stream to be close.